### PR TITLE
Suggest snc/redis-bundle on composer.json

### DIFF
--- a/Bitter/Bitter.php
+++ b/Bitter/Bitter.php
@@ -7,5 +7,4 @@ namespace Rezzza\Bundle\BitterBundle\Bitter;
  */
 class Bitter extends FreeAgent\Bitter\Bitter
 {
-
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -16,16 +16,12 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('rezzza_bitter');
 
-        $rootNode
+        $treeBuilder->root('rezzza_bitter')
             ->children()
                 ->scalarNode('redis_client')
-                    ->validate()
-                        ->ifTrue(function($v) { return empty($v); })
-                        ->thenInvalid('The "redis_client" option must be set')
-                    ->end()
-                    ->defaultValue('snc_redis.default_client')
+                    ->isRequired()
+                    ->cannotBeEmpty()
                 ->end()
             ->end()
         ;

--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,6 @@
 BitterBundle Documentation
 ==========================
 
-.. image:: https://secure.travis-ci.org/rezzza/BitterBundle.png?branch=master
-   :target: http://travis-ci.org/rezzza/BitterBundle
-
 BitterBundle is a powerful analytics Symfony Bundle based on `Bitter <https://github.com/jeremyFreeAgent/Bitter/>`_ library using Redis bitmaps.
 
 .. note::
@@ -20,22 +17,20 @@ Bitter uses `Redis <http://redis.io>`_ (version >=2.6).
 
 Configuration
 -------------
-If you want to use the default values:
 
-.. code-block:: yaml
-
-    rezzza_bitter: ~
-
-Default values are:
-
-* redis_client: snc_redis.default_client
-
-If you want to use custom values:
+Using `SncRedisBundle <https://github.com/snc/SncRedisBundle>`_ redis client:
 
 .. code-block:: yaml
 
     rezzza_bitter:
-      redis_client: your.very.best.redis.client
+        redis_client: snc_redis.default_client
+
+Using custom redis client:
+
+.. code-block:: yaml
+
+    rezzza_bitter:
+        redis_client: your.very.best.redis.client
 
 Basic usage
 -----------
@@ -58,3 +53,4 @@ Mark user 404 as active and has been kicked by Chuck Norris:
 Todo
 ----
 * Add dashboard controller.
+* Add tests

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,10 @@
     "require-dev": {
         "mageekguy/atoum": "dev-master"
     },
+    "suggest": {
+        "snc/redis-bundle": "Redis bundle for Symfony 2",
+        "ext-phpredis": "Redis C extension for PHP"
+    },
     "autoload":     {
         "psr-0": { "Rezzza\\BitterBundle": "" }
     },
@@ -27,5 +31,10 @@
     "minimum-stability": "dev",
     "config": {
         "bin-dir": "bin"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0.x-dev"
+        }
     }
 }


### PR DESCRIPTION
An other thing,

Why having snc_redis client by default if user has not snc/redis-bundle ? (it's only suggested and it has to be).

I guess we should show an example of usage for snc/redis-bundle but not provide a default value on `redis_client`, any thought ?
