### PR TITLE
Better examples, fix formatting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,18 +4,14 @@ BitterBundle Documentation
 .. image:: https://secure.travis-ci.org/rezzza/BitterBundle.png?branch=master
   :target: http://travis-ci.org/rezzza/BitterBundle
 
-BitterBundle is a powerful analytics Symfony Bundle based on `Bitter <https://github.com/jeremyFreeAgent/Bitter/>`_ library using Redis bitmaps.
-
-.. note::
-    Please look at `Bitter <https://github.com/jeremyFreeAgent/Bitter/>`_ for more info about what it can do.
-
-Please see `Bitter <http://bitter.free-agent.fr/>`_  for more info and documentation about this project.
+BitterBundle makes it easy to use the `Bitter library <https://github.com/jeremyFreeAgent/Bitter/>`_ to implement real-time 
+highly-scalable analytics using Redis bitmaps in your Symfony 2 project. Please see the `Bitter library website <http://bitter.free-agent.fr/>`_  for more info and documentation about this project.
 
 Installation
 ------------
-Use `Composer <https://github.com/composer/composer/>`_ to install: `rezzza/bitter-bundle`.
+Use `Composer <https://github.com/composer/composer/>`_ to install: ``rezzza/bitter-bundle``.
 
-In your `composer.json` you should have:
+In your ``composer.json`` you should have:
 
 .. code-block:: yaml
 
@@ -25,7 +21,7 @@ In your `composer.json` you should have:
         }
     }
 
-Then update your `AppKernel.php` to register the bundle with:
+Then update your ``AppKernel.php`` to register the bundle with:
 
 .. code-block:: php
 
@@ -50,17 +46,14 @@ Using custom redis client:
     rezzza_bitter:
         redis_client: your.very.best.redis.client
 
-You can also configure custom values for `prefix_key` and `expire_timeout`:
+You can also configure custom values for ``prefix_key`` and ``expire_timeout``:
 
 .. code-block:: yaml
 
     rezzza_bitter:
         redis_client: snc_redis.default
-        prefix_key: jack_bauer
-        expire_timeout: 404
-
-.. note::
-    Default values for `prefix_key` and `expire_timeout` are **bitter** and **60**.
+        prefix_key: my_app  # default - bitter
+        expire_timeout: 300 # default - 60
 
 Basic usage
 -----------
@@ -70,12 +63,12 @@ Get Bitter:
 
     $bitter = $this->container->get('rezzza.bitter');
 
-Mark user 404 as active and has been kicked by Chuck Norris:
+Mark user 123 as active and has played a song:
 
 .. code-block:: php
 
-    $bitter->mark('active', 404);
-    $bitter->mark('kicked_by_chuck_norris', 404);
+    $bitter->mark('active', 123);
+    $bitter->mark('song:played', 123);
 
 .. note::
     Please look at `Bitter <https://github.com/jeremyFreeAgent/Bitter/>`_ for all examples.


### PR DESCRIPTION
use better examples - user id 404 might be mistaken for an http status code, and 'song:played' is a more realistic action (to most people).

Also fix formatting (this file is using restructured text, not markdown).
